### PR TITLE
Make required proxy dependency explicit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "purescript-prelude": "^3.1.0",
     "purescript-console": "^3.0.0",
-    "purescript-properties": "^0.2.0"
+    "purescript-properties": "^0.2.0",
+    "purescript-proxy": "^2.1.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",


### PR DESCRIPTION
Without it, the package fails to build with:
```
Error found:
in module Data.Lattice.Verify
at bower_components/purescript-lattice/src/Data/Lattice/Verify.purs line 4, column 1 - line 4, column 26

  Module Type.Proxy was not found.
  Make sure the source file exists, and that it has been provided as an input to the compiler.
```

(Maybe a `devDependency` was bringing it in?)